### PR TITLE
Lucas rufo/gitignore mod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ auth-service
 eureka-service
 config-service
 zuul-service
-configuration-repo
 
 /.metadata/
 
@@ -104,6 +103,15 @@ hibernate.cfg.xml
 
 # sonarlint modules
 .sonarlint
+
+# config files (bootstrap.yml will stay on repo, but no need to update it)
+bootstrap.yml
+application.yml
+
+# Target Directory
+target/
+
+.vscode/
 
 # hook-deps
 .hook-deps/

--- a/.gitignore
+++ b/.gitignore
@@ -1,29 +1,109 @@
-/target/
-!.mvn/wrapper/maven-wrapper.jar
+# repos
+project-service
+auth-service
+eureka-service
+config-service
+zuul-service
+configuration-repo
 
-### STS ###
-.apt_generated
-.classpath
-.factorypath
-.project
-.settings
-.springBeans
-.sts4-cache
+/.metadata/
 
-### IntelliJ IDEA ###
-.idea
-*.iws
-*.iml
-*.ipr
+# Compiled class file
+*.class 
 
-### NetBeans ###
-/nbproject/private/
-/build/
-/nbbuild/
-/dist/
-/nbdist/
-/.nb-gradle/
+# Log file 
+*.log 
 
-# config files (bootstrap.yml will stay on repo, but no need to update it)
-bootstrap.yml
-application.yml
+# BlueJ files 
+*.ctxt 
+
+# Mobile Tools for Java (J2ME) 
+.mtj.tmp/ 
+
+# Package Files # 
+*.jar 
+*.war 
+*.ear 
+*.zip 
+*.tar.gz 
+*.rar 
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml 
+hs_err_pid* 
+
+# # Created by https://www.gitignore.io/api/eclipse 
+
+
+### Eclipse ### 
+.metadata 
+bin/ 
+tmp/ 
+*.tmp 
+*.bak 
+*.swp 
+*~.nib 
+local.properties 
+.settings/ 
+.loadpath 
+.recommenders 
+
+# Eclipse Core 
+.project 
+Servers/
+RemoteSystemsTempFiles/
+
+# External tool builders 
+.externalToolBuilders/ 
+
+# Locally stored "Eclipse launch configurations" 
+*.launch 
+
+# PyDev specific (Python IDE for Eclipse) 
+*.pydevproject 
+
+# CDT-specific (C/C++ Development Tooling) 
+.cproject 
+
+# JDT-specific (Eclipse Java Development Tools) 
+.classpath 
+
+# Java annotation processor (APT) 
+.factorypath 
+
+# PDT-specific (PHP Development Tools) 
+.buildpath 
+
+# sbteclipse plugin 
+.target 
+
+# Tern plugin 
+.tern-project 
+
+# TeXlipse plugin 
+.texlipse 
+
+# STS (Spring Tool Suite) 
+.springBeans 
+
+# Code Recommenders 
+.recommenders/ 
+
+# Scala IDE specific (Scala & Java development for Eclipse) 
+.cache-main 
+.scala_dependencies 
+.worksheet 
+
+# .properties files
+*.properties
+
+# package-lock.json
+package-lock.json
+
+# hibernate config xml
+hibernate.cfg.xml
+
+# sonarlint modules
+.sonarlint
+
+# hook-deps
+.hook-deps/


### PR DESCRIPTION
Modified .gitignore to include `hook-deps` folder. Two commits were made because the first was the meta repo's .gitignore with the `hook-deps` folder added. The second reversed this change by copying the original .gitignore of this repo and adding the new lines.